### PR TITLE
Updated Lower(order_id) with Like keyword

### DIFF
--- a/DAL/Backend/Tasks/Orders.cs
+++ b/DAL/Backend/Tasks/Orders.cs
@@ -28,7 +28,7 @@ namespace MixERP.Sales.DAL.Backend.Tasks
                 var sql = new Sql("SELECT * FROM sales.order_search_view");
                 sql.Where("value_date BETWEEN @0 AND @1", search.From, search.To);
                 sql.And("expected_date BETWEEN @0 AND @1", search.ExpectedFrom, search.ExpectedTo);
-                sql.And("LOWER(order_id) LIKE @0", search.Id.ToSqlLikeExpression().ToLower());
+                sql.And("order_id::text LIKE @0", search.Id.ToSqlLikeExpression().ToLower());
                 sql.And("LOWER(reference_number) LIKE @0", search.ReferenceNumber.ToSqlLikeExpression().ToLower());
                 sql.And("LOWER(customer) LIKE @0", search.Customer.ToSqlLikeExpression().ToLower());
                 sql.And("LOWER(terms) LIKE @0", search.Terms.ToSqlLikeExpression().ToLower());


### PR DESCRIPTION
order_id is of datetype bigint and Lower(order_id) is an invalid function, Lower(int) is a valid function, due to this sales listing page was broken and the list was not working ... this change should fix it.