### PR TITLE
Fixed divide by zero error in taxableTotal

### DIFF
--- a/Views/Ticket/Index.cshtml
+++ b/Views/Ticket/Index.cshtml
@@ -11,7 +11,8 @@
     decimal taxTotal = Model.View.Tax;
 }
 @{
-    decimal discountRate = Math.Round(Model.View.Discount * 100 / Model.View.TaxableTotal, 1);
+    var taxableTotalValue = Model.View.TaxableTotal == 0 ? 1 : Model.View.TaxableTotal;
+    decimal discountRate = Math.Round(Model.View.Discount * 100 / taxableTotalValue, 1);
 }
 
 <link rel="stylesheet" type="text/css" href="/Areas/MixERP.Sales/styles/ticket/index.css" />


### PR DESCRIPTION
For a non-table item Model.View.TaxableTotal is set as zero, in this case there is a divide by zero error through on this page. In order to avoid it i have just added a fix to avoid this issue, but not sure what actually this discount rate is doing here. Could you please run through the core team and make sure we dont have a divide by zero error on this page when a non-taxable item is selected in checkout